### PR TITLE
Fixes issue when loading the module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "simplecsv",
   "version": "0.0.47",
   "description": "Fast and compact CSV parser for parsing CSV with CSV to JSON support.",
+  "main": "simplecsv.js",
   "keywords": [
     "csv",
     "csvparser",


### PR DESCRIPTION
It seems that this project is missing the `main` entry from `pacakge.json` making this project not being able to load as described in the examples.

Prior to this fix I was encountering following issue when executing my node app:

``` bash
miksu:project miksu$ node server.js 

module.js:340
    throw err;
          ^
Error: Cannot find module 'simplecsv'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (.../project/server.js:8:17)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```
